### PR TITLE
Use Linux bundle layout and reset hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,16 +127,19 @@ jobs:
         run: |
           mkdir -p release-artifacts
 
-          # 1. Prepare Binary (Search for the most likely release binary)
+          # 1. Prepare Binary (Linux bundle layout)
           BINARY_FILE=$(find target -name "${APP_NAME}" -type f -executable | grep -v "deps/" | grep "release" | head -1)
           if [ -z "$BINARY_FILE" ]; then
             echo "Error: Binary not found"
             exit 1
           fi
-          cp "$BINARY_FILE" ./release-artifacts/
+          mkdir -p ./release-artifacts/bin
+          mkdir -p ./release-artifacts/lib/${APP_NAME}
+          cp "$BINARY_FILE" ./release-artifacts/bin/${APP_NAME}
+          ln -s "./bin/${APP_NAME}" "./release-artifacts/${APP_NAME}"
 
-          # 2. Add Assets
-          cp -r ./assets ./release-artifacts/
+          # 2. Add Assets (Linux expects ../lib/{product}/assets)
+          cp -r ./assets "./release-artifacts/lib/${APP_NAME}/assets"
 
           # 3. Add Launcher Script
           if [ -f "./scripts/course-pilot-launcher.sh" ]; then
@@ -144,8 +147,8 @@ jobs:
             chmod +x ./release-artifacts/course-pilot-launcher
           fi
 
-          chmod +x "./release-artifacts/${APP_NAME}"
-          strip "./release-artifacts/${APP_NAME}" || true
+          chmod +x "./release-artifacts/bin/${APP_NAME}"
+          strip "./release-artifacts/bin/${APP_NAME}" || true
 
           # 4. Create Tarball
           tar -czf "${{ matrix.artifact }}" -C release-artifacts .

--- a/scripts/course-pilot-launcher.sh
+++ b/scripts/course-pilot-launcher.sh
@@ -8,7 +8,7 @@ set -e
 
 APP_NAME="course_pilot"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BIN_PATH="$SCRIPT_DIR/$APP_NAME"
+BIN_PATH="$SCRIPT_DIR/bin/$APP_NAME"
 
 # Colors for output
 RED='\033[0;31m'
@@ -127,11 +127,15 @@ check_dependencies
 
 # 2. Check if binary exists
 if [ ! -f "$BIN_PATH" ]; then
-    # Fallback to looking in the current directory if script is moved
-    BIN_PATH="./$APP_NAME"
+    # Fallback to legacy layout (binary alongside script)
+    BIN_PATH="$SCRIPT_DIR/$APP_NAME"
     if [ ! -f "$BIN_PATH" ]; then
-        log_err "Binary '$APP_NAME' not found in $SCRIPT_DIR or current directory."
-        exit 1
+        # Fallback to looking in the current directory if script is moved
+        BIN_PATH="./$APP_NAME"
+        if [ ! -f "$BIN_PATH" ]; then
+            log_err "Binary '$APP_NAME' not found in $SCRIPT_DIR/bin, $SCRIPT_DIR, or current directory."
+            exit 1
+        fi
     fi
 fi
 

--- a/src/ui/hooks.rs
+++ b/src/ui/hooks.rs
@@ -121,11 +121,23 @@ pub fn use_load_modules_state(
 ) -> (Signal<Vec<Module>>, LoadState) {
     let mut modules = use_signal(Vec::new);
     let course_id = course_id.clone();
+    let mut course_id_signal = use_signal(|| course_id.clone());
+    if *course_id_signal.read() != course_id {
+        course_id_signal.set(course_id.clone());
+    }
     let load_state = use_load_state();
     let mut is_loading = load_state.is_loading;
     let mut error = load_state.error;
+    let mut last_course_id = use_signal(|| course_id.clone());
+    if *last_course_id.read() != course_id {
+        last_course_id.set(course_id.clone());
+        modules.set(Vec::new());
+        error.set(None);
+        is_loading.set(true);
+    }
 
     use_effect(move || {
+        let course_id = course_id_signal.read().clone();
         is_loading.set(true);
         error.set(None);
 
@@ -239,11 +251,23 @@ pub fn use_load_video_state(
 ) -> (Signal<Option<Video>>, LoadState) {
     let mut video = use_signal(|| None);
     let video_id = video_id.clone();
+    let mut video_id_signal = use_signal(|| video_id.clone());
+    if *video_id_signal.read() != video_id {
+        video_id_signal.set(video_id.clone());
+    }
     let load_state = use_load_state();
     let mut is_loading = load_state.is_loading;
     let mut error = load_state.error;
+    let mut last_video_id = use_signal(|| video_id.clone());
+    if *last_video_id.read() != video_id {
+        last_video_id.set(video_id.clone());
+        video.set(None);
+        error.set(None);
+        is_loading.set(true);
+    }
 
     use_effect(move || {
+        let video_id = video_id_signal.read().clone();
         is_loading.set(true);
         error.set(None);
 
@@ -394,11 +418,23 @@ pub fn use_load_videos_by_course_state(
 ) -> (Signal<Vec<Video>>, LoadState) {
     let mut videos = use_signal(Vec::new);
     let course_id = course_id.clone();
+    let mut course_id_signal = use_signal(|| course_id.clone());
+    if *course_id_signal.read() != course_id {
+        course_id_signal.set(course_id.clone());
+    }
     let load_state = use_load_state();
     let mut is_loading = load_state.is_loading;
     let mut error = load_state.error;
+    let mut last_course_id = use_signal(|| course_id.clone());
+    if *last_course_id.read() != course_id {
+        last_course_id.set(course_id.clone());
+        videos.set(Vec::new());
+        error.set(None);
+        is_loading.set(true);
+    }
 
     use_effect(move || {
+        let course_id = course_id_signal.read().clone();
         is_loading.set(true);
         error.set(None);
 


### PR DESCRIPTION
Change release workflow to package the binary under release-artifacts/bin, move assets into release-artifacts/lib/${APP_NAME}/assets, create a symlink for the executable, and adjust chmod/strip paths. Update launcher script to prefer bin/$APP_NAME with fallbacks to legacy locations. Update UI hooks to track course/video id signals and clear cached state when the id changes to avoid stale UI data.
that fixes #14 and #13 